### PR TITLE
Automatically add missing parameters

### DIFF
--- a/docstring_builder/numpydoc.py
+++ b/docstring_builder/numpydoc.py
@@ -21,13 +21,14 @@ def format_parameters(parameters, sig):
     docstring = ""
     # display parameters in order given in function signature
     for param_name, param in sig.parameters.items():
-        param_doc = parameters[param_name]
         docstring += param_name.strip()
         if param.annotation is not Parameter.empty:
             docstring += f" : {format_annotation(param.annotation)}"
         docstring += newline
-        docstring += indent_para(param_doc)
-        docstring += newline
+        if param_name in parameters:
+            param_doc = parameters[param_name]
+            docstring += indent_para(param_doc)
+            docstring += newline
     docstring += newline
     return docstring
 
@@ -58,6 +59,9 @@ def doc(
     parameters: Mapping = None,
     returns: Mapping = None,
 ):
+    if parameters is None:
+        parameters = dict()
+
     def decorator(f):
         docstring = ""
 
@@ -68,20 +72,14 @@ def doc(
             docstring += newline
 
         # check parameters against function signature
-        # TODO strict=False generate docs for missing params
         sig = signature(f)
-        expected_param_names = list(sig.parameters)
-        given_param_names = list(parameters) if parameters else []
-        for e in expected_param_names:
-            if e not in given_param_names:
-                raise DocumentationError(f"Parameter {e} not documented.")
-        for g in given_param_names:
-            if g not in expected_param_names:
+        for g in parameters:
+            if g not in sig.parameters:
                 raise DocumentationError(
                     f"Parameter {g} not found in function signature."
                 )
 
-        if parameters:
+        if sig.parameters:
             docstring += "Parameters" + newline
             docstring += "----------" + newline
             docstring += format_parameters(parameters, sig)

--- a/tests/test_numpydoc.py
+++ b/tests/test_numpydoc.py
@@ -10,7 +10,7 @@ from docstring_builder.numpydoc import DocumentationError, doc
 def test_basic():
     # noinspection PyUnusedLocal
     @doc(
-        summary="A function with simple arguments.",
+        summary="A function with simple parameters.",
         parameters={
             "bar": "This is very bar.",
             "baz": "This is totally baz.",
@@ -24,7 +24,7 @@ def test_basic():
 
     expected = cleandoc(
         """
-    A function with simple arguments.
+    A function with simple parameters.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def test_basic():
 def test_long_summary():
     # noinspection PyUnusedLocal
     @doc(
-        summary="A function with simple arguments and a very long summary. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",  # noqa
+        summary="A function with simple parameters and a very long summary. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",  # noqa
         parameters={
             "bar": "This is very bar.",
             "baz": "This is totally baz.",
@@ -60,7 +60,7 @@ def test_long_summary():
 
     expected = cleandoc(
         """
-    A function with simple arguments and a very long summary. Lorem ipsum
+    A function with simple parameters and a very long summary. Lorem ipsum
     dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
     incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
     quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -89,7 +89,7 @@ def test_long_summary():
 def test_long_param_doc():
     # noinspection PyUnusedLocal
     @doc(
-        summary="A function with simple arguments and a very long param doc.",
+        summary="A function with simple parameters and a very long param doc.",
         parameters={
             "bar": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",  # noqa
             "baz": "This is totally baz.",
@@ -103,7 +103,7 @@ def test_long_param_doc():
 
     expected = cleandoc(
         """
-    A function with simple arguments and a very long param doc.
+    A function with simple parameters and a very long param doc.
 
     Parameters
     ----------
@@ -129,41 +129,62 @@ def test_long_param_doc():
 
 
 def test_missing_param():
-    with pytest.raises(DocumentationError):
-        # noinspection PyUnusedLocal
-        @doc(
-            summary="A function with simple arguments.",
-            parameters={
-                "bar": "This is very bar.",
-                # baz parameter is missing
-            },
-            returns={
-                "qux": "Amazingly qux.",
-            },
-        )
-        def f(bar, baz):
-            pass
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function with simple parameters.",
+        parameters={
+            "bar": "This is very bar.",
+            # baz parameter is missing
+        },
+    )
+    def f(bar, baz):
+        pass
+
+    expected = cleandoc(
+        """
+    A function with simple parameters.
+
+    Parameters
+    ----------
+    bar
+        This is very bar.
+    baz
+
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
 
 
 def test_missing_params():
-    with pytest.raises(DocumentationError):
-        # noinspection PyUnusedLocal
-        @doc(
-            summary="A function with simple arguments.",
-            # no parameters given at all
-            returns={
-                "qux": "Amazingly qux.",
-            },
-        )
-        def f(bar, baz):
-            pass
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function with simple parameters.",
+        # no parameters given at all
+    )
+    def f(bar, baz):
+        pass
+
+    expected = cleandoc(
+        """
+    A function with simple parameters.
+
+    Parameters
+    ----------
+    bar
+    baz
+
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
 
 
 def test_extra_param():
     with pytest.raises(DocumentationError):
         # noinspection PyUnusedLocal
         @doc(
-            summary="A function with simple arguments.",
+            summary="A function with simple parameters.",
             parameters={
                 "bar": "This is very bar.",
                 "baz": "This is totally baz.",


### PR DESCRIPTION
Make it optional to document parameters. Generate entries in parameters section for all parameters in the signature.