### PR TITLE
Handle returns

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+ignore =
+    # whitespace before ':' - doesn't work well with black
+    E203
+    # module level import not at top of file
+    E402
+    # line too long - let black worry about that
+    E501
+    # do not assign a lambda expression, use a def
+    E731
+    # line break before binary operator
+    W503

--- a/docstring_builder/numpydoc.py
+++ b/docstring_builder/numpydoc.py
@@ -32,7 +32,7 @@ def format_parameters(parameters, sig):
     for param_name, param in sig.parameters.items():
         docstring += param_name.strip()
         if param.annotation is not Parameter.empty:
-            docstring += f" : {format_annotation(param.annotation)}"
+            docstring += f" : {format_type(param.annotation)}"
         docstring += newline
         if param_name in parameters:
             param_doc = parameters[param_name]
@@ -42,7 +42,7 @@ def format_parameters(parameters, sig):
     return docstring
 
 
-def format_annotation(t):
+def format_type(t):
     # This is probably a bit hacky, could be improved.
     s = repr(t)
     if s.startswith("<class"):
@@ -67,7 +67,7 @@ def format_returns_simple(returns, sig):
         docstring = para(returns)
     else:
         # provide the type
-        docstring = format_annotation(return_type)
+        docstring = format_type(return_type)
         docstring += newline
         docstring += indent_para(returns)
     docstring += newline
@@ -76,18 +76,18 @@ def format_returns_simple(returns, sig):
 
 def format_returns_named(returns, sig):
     docstring = ""
-    return_type = sig.return_annotation
+    return_annotation = sig.return_annotation
 
     # handle possibility of multiple return values
-    if typing_get_origin(return_type) is tuple:
+    if typing_get_origin(return_annotation) is tuple:
         # trust the return annotation regarding the number of return values
-        return_types = typing_get_args(return_type)
-    elif return_type is Parameter.empty:
+        return_types = typing_get_args(return_annotation)
+    elif return_annotation is Parameter.empty:
         # trust the documentation regarding number of return values
         return_types = [Parameter.empty] * len(returns)
     else:
         # assume a single return value
-        return_types = [return_type]
+        return_types = [return_annotation]
 
     if len(returns) > len(return_types):
         # TODO raise
@@ -97,12 +97,12 @@ def format_returns_named(returns, sig):
         # TODO fill
         pass
 
-    for (param_name, param_doc), param_type in zip(returns.items(), return_types):
-        docstring += param_name.strip()
-        if param_type is not Parameter.empty:
-            docstring += f" : {format_annotation(param_type)}"
+    for (return_name, return_doc), return_type in zip(returns.items(), return_types):
+        docstring += return_name.strip()
+        if return_type is not Parameter.empty:
+            docstring += f" : {format_type(return_type)}"
         docstring += newline
-        docstring += indent_para(param_doc)
+        docstring += indent_para(return_doc)
         docstring += newline
     docstring += newline
 

--- a/docstring_builder/numpydoc.py
+++ b/docstring_builder/numpydoc.py
@@ -34,10 +34,9 @@ def format_parameters(parameters, sig):
         if param.annotation is not Parameter.empty:
             docstring += f" : {format_type(param.annotation)}"
         docstring += newline
-        if param_name in parameters:
-            param_doc = parameters[param_name]
-            docstring += indent_para(param_doc)
-            docstring += newline
+        param_doc = parameters[param_name]
+        docstring += indent_para(param_doc)
+        docstring += newline
     docstring += newline
     return docstring
 
@@ -95,12 +94,10 @@ def format_returns_named(returns, sig):
         return_types = [return_annotation]
 
     if len(returns) > len(return_types):
-        # TODO raise
-        pass
+        raise DocumentationError("more return values documented than types")
 
     if len(returns) < len(return_types):
-        # TODO fill
-        pass
+        raise DocumentationError("more return types than values documented")
 
     for (return_name, return_doc), return_type in zip(returns.items(), return_types):
         docstring += return_name.strip()
@@ -133,6 +130,9 @@ def doc(
 
         # check parameters against function signature
         sig = signature(f)
+        for e in sig.parameters:
+            if e not in parameters:
+                raise DocumentationError(f"Parameter {e} not documented.")
         for g in parameters:
             if g not in sig.parameters:
                 raise DocumentationError(

--- a/docstring_builder/numpydoc.py
+++ b/docstring_builder/numpydoc.py
@@ -80,8 +80,13 @@ def format_returns_named(returns, sig):
 
     # handle possibility of multiple return values
     if typing_get_origin(return_annotation) is tuple:
-        # trust the return annotation regarding the number of return values
-        return_types = typing_get_args(return_annotation)
+        typing_args = typing_get_args(return_annotation)
+        if Ellipsis in typing_args:
+            # treat as a single return value
+            return_types = [return_annotation]
+        else:
+            # treat as multiple return values
+            return_types = typing_args
     elif return_annotation is Parameter.empty:
         # trust the documentation regarding number of return values
         return_types = [Parameter.empty] * len(returns)

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,7 +204,7 @@ files = [
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -231,4 +231,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "905a21b0f8ddf827c4696ba6c05c8468849b1170576d62d4da4cd416a09ce226"
+content-hash = "c6bafb781c3418b31209f50c962f02f5a930b1d7afcdc996b5ecbe74537b3aae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [{include = "docstring_builder"}]
 
 [tool.poetry.dependencies]
 python = "^3.7"
+typing_extensions = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tests/test_numpydoc.py
+++ b/tests/test_numpydoc.py
@@ -422,3 +422,28 @@ def test_returns_multi_typed():
     )
     actual = getdoc(f)
     compare(actual, expected)
+
+
+def test_returns_multi_typed_ellipsis():
+    @doc(
+        summary="A function.",
+        returns={
+            "spam": "The more the better.",
+        },
+    )
+    def f() -> Tuple[str, ...]:
+        return "spam", "spam", "spam", "spam"
+
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    spam : Tuple[str, ...]
+        The more the better.
+
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)

--- a/tests/test_numpydoc.py
+++ b/tests/test_numpydoc.py
@@ -1,5 +1,5 @@
 from inspect import cleandoc, getdoc
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import pytest
 from testfixtures import compare
@@ -264,6 +264,158 @@ def test_parameter_types():
     spam : Union[list, str]
         Very healthy.
     eggs : Dict[str, Sequence]
+        Good on toast.
+
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_basic():
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function.",
+        returns="Amazingly qux.",
+    )
+    def f():
+        return 42
+
+    # this isn't strictly kosher as numpydoc demands type is always given
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    Amazingly qux.
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_basic_typed():
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function.",
+        returns="Amazingly qux.",
+    )
+    def f() -> int:
+        return 42
+
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    int
+        Amazingly qux.
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_named():
+    @doc(
+        summary="A function.",
+        returns={
+            "qux": "Amazingly qux.",
+        },
+    )
+    def f():
+        return 42
+
+    # this isn't strictly kosher as numpydoc demands type is always given
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    qux
+        Amazingly qux.
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_named_typed():
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function.",
+        returns={
+            "qux": "Amazingly qux.",
+        },
+    )
+    def f() -> int:
+        return 42
+
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    qux : int
+        Amazingly qux.
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_multi():
+    @doc(
+        summary="A function.",
+        returns={
+            "spam": "Very healthy.",
+            "eggs": "Good on toast.",
+        },
+    )
+    def f():
+        return "hello", 42
+
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    spam
+        Very healthy.
+    eggs
+        Good on toast.
+
+    """
+    )
+    actual = getdoc(f)
+    compare(actual, expected)
+
+
+def test_returns_multi_typed():
+    @doc(
+        summary="A function.",
+        returns={
+            "spam": "Very healthy.",
+            "eggs": "Good on toast.",
+        },
+    )
+    def f() -> Tuple[str, int]:
+        return "hello", 42
+
+    expected = cleandoc(
+        """
+    A function.
+
+    Returns
+    -------
+    spam : str
+        Very healthy.
+    eggs : int
         Good on toast.
 
     """

--- a/tests/test_numpydoc.py
+++ b/tests/test_numpydoc.py
@@ -1,5 +1,5 @@
 from inspect import cleandoc, getdoc
-from typing import Dict, Optional, Sequence, Tuple, Union
+from typing import Dict, Sequence, Tuple, Union
 
 import pytest
 from testfixtures import compare
@@ -215,7 +215,7 @@ def test_parameter_types():
     )
     def f(
         bar: int,
-        baz: Optional[str],  # N.B., this is shorthand for Union
+        baz: str,
         qux: Sequence[str],
         spam: Union[list, str],
         eggs: Dict[str, Sequence],
@@ -230,7 +230,7 @@ def test_parameter_types():
     ----------
     bar : int
         This is very bar.
-    baz : Union[str, NoneType]
+    baz : str
         This is totally baz.
     qux : Sequence[str]
         Many strings.

--- a/tests/test_numpydoc.py
+++ b/tests/test_numpydoc.py
@@ -129,55 +129,28 @@ def test_long_param_doc():
 
 
 def test_missing_param():
-    # noinspection PyUnusedLocal
-    @doc(
-        summary="A function with simple parameters.",
-        parameters={
-            "bar": "This is very bar.",
-            # baz parameter is missing
-        },
-    )
-    def f(bar, baz):
-        pass
-
-    expected = cleandoc(
-        """
-    A function with simple parameters.
-
-    Parameters
-    ----------
-    bar
-        This is very bar.
-    baz
-
-    """
-    )
-    actual = getdoc(f)
-    compare(actual, expected)
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            parameters={
+                "bar": "This is very bar.",
+                # baz parameter is missing
+            },
+        )
+        def f(bar, baz):
+            pass
 
 
 def test_missing_params():
-    # noinspection PyUnusedLocal
-    @doc(
-        summary="A function with simple parameters.",
-        # no parameters given at all
-    )
-    def f(bar, baz):
-        pass
-
-    expected = cleandoc(
-        """
-    A function with simple parameters.
-
-    Parameters
-    ----------
-    bar
-    baz
-
-    """
-    )
-    actual = getdoc(f)
-    compare(actual, expected)
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            # no parameters given at all
+        )
+        def f(bar, baz):
+            pass
 
 
 def test_extra_param():
@@ -447,3 +420,63 @@ def test_returns_multi_typed_ellipsis():
     )
     actual = getdoc(f)
     compare(actual, expected)
+
+
+def test_returns_extra_value():
+    # here there are more return values documented than there are types
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            returns={
+                "spam": "Surprisingly healthy.",
+                "eggs": "Good on toast.",
+            },
+        )
+        def f() -> str:
+            return "dinner"
+
+
+def test_returns_extra_values():
+    # here there are more return values documented than there are types
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            returns={
+                "spam": "Surprisingly healthy.",
+                "eggs": "Good on toast.",
+                "toast": "Good with eggs.",
+            },
+        )
+        def f() -> Tuple[str, str]:
+            return "spam", "eggs"
+
+
+def test_returns_extra_type():
+    # here there are more return types than return values documented
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            returns={
+                "spam": "Surprisingly healthy.",
+            },
+        )
+        def f() -> Tuple[str, str]:
+            return "spam", "eggs"
+
+
+def test_returns_extra_types():
+    # here there are more return types than return values documented
+    with pytest.raises(DocumentationError):
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A function with simple parameters.",
+            returns={
+                "spam": "Surprisingly healthy.",
+                "eggs": "Good on toast.",
+            },
+        )
+        def f() -> Tuple[str, str, str]:
+            return "spam", "eggs", "toast"


### PR DESCRIPTION
Support for different returns, including single and multi, typed and not typed.

Also revert to strict behaviour for parameters, raise error if any undocumented.